### PR TITLE
ELL -> ELLA and add Ellaism network mapping

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
@@ -10,7 +10,7 @@ import org.kethereum.erc55.withERC55Checksum
 import org.kethereum.model.Address
 import java.io.File
 
-val networkMapping = mapOf("etc" to 61, "eth" to 1, "kov" to 42, "rin" to 4, "rop" to 3, "rsk" to 40)
+val networkMapping = mapOf("etc" to 61, "eth" to 1, "kov" to 42, "rin" to 4, "rop" to 3, "rsk" to 40, "ella" to 64)
 
 fun main(args: Array<String>) {
 

--- a/tokens/ella/0x991e7Fe4b05f2b3db1D788e705963f5D647b0044.json
+++ b/tokens/ella/0x991e7Fe4b05f2b3db1D788e705963f5D647b0044.json
@@ -3,7 +3,7 @@
   "name": "Ella Mining Tokens",
   "address": "0x991e7Fe4b05f2b3db1D788e705963f5D647b0044",
   "decimals": "18",
-  "website": "https://pool.ellaism.org ",
+  "website": "https://pool.ellaism.org",
   "logo": {
     "src": "",
     "width": "",


### PR DESCRIPTION
* If the folder are named by blockchain tickers, then it should be "ella" instead of "ell" for Ellaism.
* Fixed a whitespace typo in MINING Ellaism token.
* Added network id mapping for ella in `tokens/Main.kt`.