### PR TITLE
Update Sharder(SS) Token info

### DIFF
--- a/tokens/eth/0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4.json
+++ b/tokens/eth/0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4.json
@@ -1,6 +1,6 @@
 {
   "symbol": "SS",
-  "address": "0xbbff862d906e348e9946bfb2132ecb157da3d4b4",
+  "address": "0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4",
   "decimals": 18,
   "name": "Sharder",
   "ens_address": "",

--- a/tokens/eth/0xbbff862d906e348e9946bfb2132ecb157da3d4b4.json
+++ b/tokens/eth/0xbbff862d906e348e9946bfb2132ecb157da3d4b4.json
@@ -1,6 +1,6 @@
 {
   "symbol": "SS",
-  "address": "0xB15fE5a123e647ba594CEa7A1E648646f95EB4AA",
+  "address": "0xbbff862d906e348e9946bfb2132ecb157da3d4b4",
   "decimals": 18,
   "name": "Sharder",
   "ens_address": "",
@@ -18,13 +18,13 @@
   "social": {
     "blog": "https://medium.com/@SharderChain",
     "chat": "",
-    "facebook": "https://www.facebook.com/PolySwarm/",
+    "facebook": "https://facebook.com/SharderChain",
     "forum": "https://community.sharder.org",
     "github": "https://github.com/Sharders",
     "gitter": "",
     "instagram": "",
     "linkedin": "",
-    "reddit": "",
+    "reddit": "https://reddit.com/r/Sharder/",
     "slack": "",
     "telegram": "https://t.me/sharder_talk",
     "twitter": "https://twitter.com/SharderChain",


### PR DESCRIPTION
Update the upgraded contract address and ref links.

Sharder Token Sharder(SS) Migration Notice: 
1. Sharder has upgraded the tokens Sharder(SS) and combined all previous contracts to the upgraded contract: 0xbbff862d906e348e9946bfb2132ecb157da3d4b4.
2. The previous contracts was locked and expired at 0:00 UTC Mar.14,2018.