### PR TITLE
Fix name of District0x and Arcade City tokens

### DIFF
--- a/tokens/eth/0x0AbdAce70D3790235af448C88547603b945604ea.json
+++ b/tokens/eth/0x0AbdAce70D3790235af448C88547603b945604ea.json
@@ -2,7 +2,7 @@
   "symbol": "DNT",
   "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
   "decimals": 18,
-  "name": "DistrictOx",
+  "name": "District0x Network Token",
   "ens_address": "",
   "website": "https://district0x.io",
   "logo": {

--- a/tokens/eth/0xAc709FcB44a43c35F0DA4e3163b117A17F3770f5.json
+++ b/tokens/eth/0xAc709FcB44a43c35F0DA4e3163b117A17F3770f5.json
@@ -2,7 +2,7 @@
   "symbol": "ARC",
   "address": "0xAc709FcB44a43c35F0DA4e3163b117A17F3770f5",
   "decimals": 18,
-  "name": "ARC",
+  "name": "Arcade Token",
   "ens_address": "",
   "website": "https://arcade.city",
   "logo": {


### PR DESCRIPTION
- District0x was spelled districtOx (letter "O" instead of number "0")
- Arcade City token was using symbol "ARC" for the name field.