### PR TITLE
VeChain mainnet split -> token renamed to VEN

### DIFF
--- a/tokens/eth/0xD850942eF8811f2A866692A623011bDE52a462C1.json
+++ b/tokens/eth/0xD850942eF8811f2A866692A623011bDE52a462C1.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "VET",
+  "symbol": "VEN",
   "address": "0xD850942eF8811f2A866692A623011bDE52a462C1",
   "decimals": 18,
   "name": "Vechain",


### PR DESCRIPTION
see e.g. https://etherscan.io/token/0xd850942ef8811f2a866692a623011bde52a462c1
https://cryptoglobalist.com/2018/07/03/important-vechain-ven-makes-changes-to-vechainthor-vet-mainnet-migration-dates/