### PR TITLE
update LinkerCoin symbol to match convention

### DIFF
--- a/tokens/eth/0x6BEB418Fc6E1958204aC8baddCf109B8E9694966.json
+++ b/tokens/eth/0x6BEB418Fc6E1958204aC8baddCf109B8E9694966.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "LNC-Linker Coin",
+  "symbol": "LNC (Linker Coin)",
   "address": "0x6BEB418Fc6E1958204aC8baddCf109B8E9694966",
   "decimals": 18,
   "name": "Linker Coin",


### PR DESCRIPTION
This bad boy is messing up our duplicate detection. The PR updates the symbol to use the same convention that other clashing symbols use.