### PR TITLE
BNB symbol update: (ERC20) suffix

### DIFF
--- a/tokens/eth/0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
+++ b/tokens/eth/0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "BNB",
+  "symbol": "BNB (ERC20)",
   "address": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
   "decimals": 18,
   "name": "BNB",


### PR DESCRIPTION
BNB will co-exist as the native token of Binance Chain, a new blockchain from Binance. This change intends to avoid any issues that might be caused by symbol conflicts in wallet apps.

This will allow for Trezor to support both `BNB` (ERC20) and `BNB` (Binance Chain). Trezor symbol lists are generated from this repository and each symbol name is unique in their data source.

Please see commentary in trezor/trezor-common#264
