### PR TITLE
BNB name update

### DIFF
--- a/tokens/eth/0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
+++ b/tokens/eth/0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
@@ -2,7 +2,7 @@
   "symbol": "BNB",
   "address": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
   "decimals": 18,
-  "name": "BNB",
+  "name": "Binance Coin",
   "ens_address": "",
   "website": "https://www.binance.com",
   "logo": {


### PR DESCRIPTION
Rename BNB to Binance Coin.

The Binance Chain token will likely be called "Binance Chain Native Token".

CC #182
