### PR TITLE
Added new Melonport token - Renamed old one.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,10 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
     compile "com.github.ethereum-lists:cilib:0.2"
 
-    compile "com.github.walleth.kethereum:erc55:0.67"
-    compile "com.github.walleth.kethereum:model:0.67"
-    compile "com.github.walleth.kethereum:functions:0.67"
+    compile "com.github.walleth.kethereum:erc55:0.70"
+    compile "com.github.walleth.kethereum:model:0.70"
+    compile "com.github.walleth.kethereum:functions:0.70"
+    compile "com.github.walleth.kethereum:crypto_impl_bouncycastle:0.70"
 
     compile 'com.beust:klaxon:5.0.3'
     compile 'com.squareup.moshi:moshi-kotlin:1.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        KOTLIN_VERSION = "1.3.11"
+        KOTLIN_VERSION = "1.3.20"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile "com.github.walleth.kethereum:functions:0.70"
     compile "com.github.walleth.kethereum:crypto_impl_bouncycastle:0.70"
 
-    compile 'com.beust:klaxon:5.0.3'
+    compile 'com.beust:klaxon:5.0.4'
     compile 'com.squareup.moshi:moshi-kotlin:1.8.0'
 }
 

--- a/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
@@ -47,7 +47,8 @@ fun checkTokenFile(file: File) {
         val token = moshi.adapter(Token::class.java).failOnUnknown().fromJson(file.readText())
 
         token?.deprecation?.let {
-            if (it.migration_type ?: "auto" != "auto") {
+            val safeMigrationType: String = it.migration_type ?: "auto"
+            if (safeMigrationType != "auto" && !safeMigrationType.startsWith("instructions:")) {
                 throw InvalidDeprecationMigrationType()
             }
 

--- a/src/test/kotlin/TheTokenChecker.kt
+++ b/src/test/kotlin/TheTokenChecker.kt
@@ -18,6 +18,13 @@ class TheTokenChecker {
         checkTokenFile(file)
     }
 
+    @Test
+    fun shouldPassForValidTokenWithDeprecationMigrationInstructions() {
+        val file = getFile("valid_deprecation_instructions/0x6475A7FA6Ed2D5180F0e0a07c2d951D12C0EDB91.json")
+
+        checkTokenFile(file)
+    }
+
 
     @Test(expected = InvalidAddress::class)
     fun shouldFailForInvalidAddress() {

--- a/src/test/resources/test_tokens/valid_deprecation_instructions/0x6475A7FA6Ed2D5180F0e0a07c2d951D12C0EDB91.json
+++ b/src/test/resources/test_tokens/valid_deprecation_instructions/0x6475A7FA6Ed2D5180F0e0a07c2d951D12C0EDB91.json
@@ -1,0 +1,17 @@
+{
+  "symbol": "NONE",
+  "name": "None",
+  "address": "0x6475A7FA6Ed2D5180F0e0a07c2d951D12C0EDB91",
+  "decimals": 0,
+  "support": {
+    "email": "ligi@ethereum.org"
+  },
+  "social": {
+    "github": "https://github.com/walleth/contracts/tree/master/NoneToken"
+  },
+  "deprecation": {
+    "new_address": "0x6475A7FA6Ed2D5180F0e0a07c2d951D12C0EDB92",
+    "migration_type": "instructions:https://medium.com/melonport-blog/mln-token-migration-instructions-196a645fc3ac",
+    "time": "2018-07-09T18:01:00Z"
+  }
+}

--- a/tokens/eth/0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1.json
+++ b/tokens/eth/0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1.json
@@ -29,5 +29,11 @@
     "telegram": "",
     "twitter": "",
     "youtube": ""
+  },
+  "deprecation": {
+    "new_address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+    "migration_type": "instructions:https://medium.com/melonport-blog/mln-token-migration-instructions-196a645fc3ac",
+    "announcement_url": "https://medium.com/melonport-blog/mln-token-migration-event-96b1c8003876",
+    "time": "2019-02-01T00:00:00Z"
   }
 }

--- a/tokens/eth/0xec67005c4E498Ec7f55E092bd1d35cbC47C91892.json
+++ b/tokens/eth/0xec67005c4E498Ec7f55E092bd1d35cbC47C91892.json
@@ -1,6 +1,6 @@
 {
-  "symbol": "MLN (old)",
-  "address": "0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1",
+  "symbol": "MLN (new)",
+  "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
   "decimals": 18,
   "name": "Melonport",
   "ens_address": "",


### PR DESCRIPTION
This is an alternative to #185.

### Changes:
* Edits old MLN token to indicate it's old.
* Adds a new MLN token object.

From other PR: 
> https://medium.com/melonport-blog/mln-token-migration-event-96b1c8003876

> Needs update for Friday, Feb 1, 2019: Update to reference the MLN token address the new one