### PR TITLE
Moving High Performance Blockchain to its own chain

### DIFF
--- a/tokens/eth/0x38c6A68304cdEfb9BEc48BbFaABA5C5B47818bb2.json
+++ b/tokens/eth/0x38c6A68304cdEfb9BEc48BbFaABA5C5B47818bb2.json
@@ -34,4 +34,5 @@
   "deprecation": {
     "migration_type": "newchain:auto:269",
     "time": "2018-10-14T18:01:00Z"
+  }
 }


### PR DESCRIPTION
High Performance Blockchain is now on its own Mainnet (based on ETH) instead of being a token, and is using Chain ID 269 ( https://github.com/ethereum-lists/chains )