### PR TITLE
LGO Token Migration

### DIFF
--- a/tokens/eth/0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa.json
+++ b/tokens/eth/0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "LGO",
+  "address": "0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
+  "decimals": 8,
+  "name": "LGO Token",
+  "ens_address": "",
+  "website": "https://lgo.group",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "",
+    "url": ""
+  },
+  "social": {
+    "blog": "https://medium.com/lgogroup",
+    "chat": "",
+    "facebook": "https://www.facebook.com/LGO.Group/",
+    "forum": "",
+    "github": "https://github.com/lgo-public",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "https://www.linkedin.com/company/lgo-group",
+    "reddit": "https://www.reddit.com/r/LegolasExchange",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/LGOGroup_",
+    "youtube": ""
+  }
+}

--- a/tokens/eth/0x123aB195DD38B1b40510d467a6a359b201af056f.json
+++ b/tokens/eth/0x123aB195DD38B1b40510d467a6a359b201af056f.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "LGO",
+  "symbol": "LGO (old)",
   "address": "0x123aB195DD38B1b40510d467a6a359b201af056f",
   "decimals": 8,
   "name": "LGO Exchange",
@@ -29,5 +29,11 @@
     "telegram": "",
     "twitter": "https://twitter.com/LGOGroup_",
     "youtube": ""
+  },
+  "deprecation": {
+    "new_address": "0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
+    "migration_type": "instructions:https://medium.com/lgogroup/lgo-token-migration-event-eae14afc5c8c",
+    "announcement_url": "https://medium.com/lgogroup/lgo-token-migration-event-eae14afc5c8c",
+    "time": "2019-07-17T06:00:00Z"
   }
 }


### PR DESCRIPTION
Add new contract address
Set old contract as deprecated

The migration of LGO token is scheduled on July 17th at 06am UTC

Blog post: https://medium.com/lgogroup/lgo-token-migration-event-eae14afc5c8c