### PR TITLE
Add LivenCoin (LVN) Token

### DIFF
--- a/tokens/eth/0xc8Cac7672f4669685817cF332a33Eb249F085475.json
+++ b/tokens/eth/0xc8Cac7672f4669685817cF332a33Eb249F085475.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "LVN",
+  "name": "LivenCoin",
+  "address": "0xc8Cac7672f4669685817cF332a33Eb249F085475",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://livenpay.io",
+  "logo": {
+    "src": "https://img.liven.com.au/external/mycrypto_logo.png",
+    "width": "128px",
+    "height": "128px",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "info@liven.com.au",
+    "url": "https://help.liven.com.au"
+  },
+  "social": {
+    "blog": "https://blog.livenpay.io",
+    "chat": "",
+    "facebook": "https://www.facebook.com/LivenPay",
+    "forum": "",
+    "github": "https://github.com/livenpay",
+    "gitter": "",
+    "instagram": "https://www.instagram.com/livenpay",
+    "linkedin": "https://www.linkedin.com/company/liven",
+    "reddit": "https://www.reddit.com/r/LivenPay",
+    "slack": "",
+    "telegram": "https://t.me/livenpay",
+    "twitter": "https://twitter.com/livenpay",
+    "youtube": "https://www.youtube.com/user/livenaustralia"
+  }
+}


### PR DESCRIPTION
LVN is issued by Liven, a mobile payment and loyalty platform for lifestyle services providers where people are rewarded with crypto for their everyday economic activity. Currently Liven has 500k+ users and 1k+ restaurant partners in Melbourne and Sydney, Australia.

[Official website](https://livenpay.io/), you can find the contract address inside the page footer
[Etherscan token tracker](https://etherscan.io/token/0xc8cac7672f4669685817cf332a33eb249f085475)

[LVN will be listed on zb.com later this month.](https://www.zb.com/up/view/1)