### PR TITLE
Add Cryptobuyer (XPT) Token ERC-20

### DIFF
--- a/tokens/eth/0x08Aa0ed0040736dd28d4c8B16Ab453b368248d19.json
+++ b/tokens/eth/0x08Aa0ed0040736dd28d4c8B16Ab453b368248d19.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "XPT",
+  "name": "Cryptobuyer Token",
+  "type": "ERC20",
+  "address": "0x08Aa0ed0040736dd28d4c8B16Ab453b368248d19",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://cryptobuyer.io",
+  "logo": {
+    "src": "https://cryptobuyer.io/static/trezor/logo.png",
+    "width": "128px",
+    "height": "128px",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "info@cryptobuyer.io",
+    "url": ""
+  },
+  "social": {
+    "blog": "https://blog.cryptobuyer.io",
+    "chat": "",
+    "facebook": "https://www.facebook.com/cryptobuyer/",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "https://www.instagram.com/cryptobuyer/",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/cryptobuyer",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
Cryptobuyer is a leading crypto assets company that allows the integration of digital currencies in daily life. Operating since 2015 with real products and services such as POS, Exchange of Digital Currencies, Crypto ATM multi-asset machine solutions, and Bit-ATM franchises. XPT; its native token will be used across every product and service offered by the company.