### PR TITLE
added token info for fake RBT token

### DIFF
--- a/tokens/eth/0x165B6749812900538402CD540c55be68411F8Ea0.json
+++ b/tokens/eth/0x165B6749812900538402CD540c55be68411F8Ea0.json
@@ -1,0 +1,14 @@
+{
+  "symbol": "RBT",
+  "address": "0x165B6749812900538402CD540c55be68411F8Ea0",
+  "decimals": 18,
+  "name": "realtybits",
+  "type": "ERC20",
+  "red_flags": [
+    {
+      "type": "suspicious",
+      "comment": "fake scam token",
+      "url": "https://etherscan.io/token/0x165B6749812900538402CD540c55be68411F8Ea0"
+    }
+  ]
+}


### PR DESCRIPTION
Adding RBT token info for a fake RealtyBits token issued on the Uniswap V2 protocol.

This token is issued using our company name (RealtyBits) which is trademarked name. It is used without our authorization and is fraudulent. RealtyBits does not currently have any issued ERC-20 tokens.