### PR TITLE
Update Utrust Token after tokenswap.

### DIFF
--- a/tokens/eth/0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38.json
+++ b/tokens/eth/0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38.json
@@ -1,0 +1,39 @@
+{
+  "symbol": "UTK",
+  "address": "0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38",
+  "decimals": 18,
+  "name": "Utrust",
+  "ens_address": "",
+  "website": "https://utrust.com",
+  "logo": {
+    "src": "https://utrust.com/wp-content/uploads/2020/09/Etherscan.png",
+    "width": "256",
+    "height": "256",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "support@utrust.com",
+    "url": ""
+  },
+  "social": {
+    "blog": "https://medium.com/@UTRUST",
+    "chat": "",
+    "facebook": "https://www.facebook.com/utrust.io",
+    "forum": "",
+    "github": "https://github.com/utrustdev/",
+    "gitter": "",
+    "instagram": "https://www.instagram.com/utrust_official/",
+    "linkedin": "https://www.linkedin.com/company/utrust-payments/",
+    "reddit": "https://www.reddit.com/r/UTRUST_Official",
+    "slack": "",
+    "telegram": "https://t.me/utrustofficial",
+    "twitter": "https://twitter.com/UTRUST",
+    "youtube": "https://www.youtube.com/UtrustPayments"
+  },
+  "deprecation": {
+    "new_address": "0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c",
+    "migration_type": "tokenswap:https://medium.com/utrust/utrust-statement-and-next-steps-on-the-kucoin-hack-bd0ddedf9080",
+    "announcement_url": "https://medium.com/utrust/utrust-statement-and-next-steps-on-the-kucoin-hack-bd0ddedf9080",
+    "time": "2020-09-30T014:39:30Z"
+  }
+}

--- a/tokens/eth/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c.json
+++ b/tokens/eth/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c.json
@@ -1,18 +1,18 @@
 {
   "symbol": "UTK",
-  "address": "0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38",
+  "address": "0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c",
   "decimals": 18,
-  "name": "UTRUST",
+  "name": "Utrust",
   "ens_address": "",
   "website": "https://utrust.com",
   "logo": {
-    "src": "",
-    "width": "",
-    "height": "",
+    "src": "https://utrust.com/wp-content/uploads/2020/09/Etherscan.png",
+    "width": "256",
+    "height": "256",
     "ipfs_hash": ""
   },
   "support": {
-    "email": "contact@utrust.io",
+    "email": "support@utrust.com",
     "url": ""
   },
   "social": {
@@ -20,14 +20,14 @@
     "chat": "",
     "facebook": "https://www.facebook.com/utrust.io",
     "forum": "",
-    "github": "",
+    "github": "https://github.com/utrustdev/",
     "gitter": "",
-    "instagram": "",
-    "linkedin": "",
+    "instagram": "https://www.instagram.com/utrust_/",
+    "linkedin": "https://www.linkedin.com/company/utrust-payments/",
     "reddit": "https://www.reddit.com/r/UTRUST_Official",
     "slack": "",
     "telegram": "https://t.me/utrustofficial",
     "twitter": "https://twitter.com/UTRUST",
-    "youtube": ""
+    "youtube": "https://www.youtube.com/UtrustPayments"
   }
 }

--- a/tokens/eth/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c.json
+++ b/tokens/eth/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c.json
@@ -22,7 +22,7 @@
     "forum": "",
     "github": "https://github.com/utrustdev/",
     "gitter": "",
-    "instagram": "https://www.instagram.com/utrust_/",
+    "instagram": "https://www.instagram.com/utrust_official/",
     "linkedin": "https://www.linkedin.com/company/utrust-payments/",
     "reddit": "https://www.reddit.com/r/UTRUST_Official",
     "slack": "",


### PR DESCRIPTION
Following the KuCoin hack, we have done a token swap which is described [here](https://medium.com/utrust/utrust-statement-and-next-steps-on-the-kucoin-hack-bd0ddedf9080?source=collection_home---4------0-----------------------).

This change is already reflected on [Etherscan](https://etherscan.io/token/0xdc9Ac3C20D1ed0B540dF9b1feDC10039Df13F99c). 

Took the change to add logo and update social media profiles. 
