### PR TITLE
Add ANTv2

### DIFF
--- a/tokens/eth/0xa117000000f279D81A1D3cc75430fAA017FA5A2e.json
+++ b/tokens/eth/0xa117000000f279D81A1D3cc75430fAA017FA5A2e.json
@@ -1,12 +1,12 @@
 {
-  "symbol": "ANT (old)",
-  "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
+  "symbol": "ANT",
+  "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
   "decimals": 18,
   "name": "Aragon",
   "ens_address": "",
   "website": "https://aragon.org",
   "logo": {
-    "src": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x960b236A07cf122663c4303350609A66A7B288C0/logo.png",
+    "src": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png",
     "width": "256",
     "height": "256",
     "ipfs_hash": ""


### PR DESCRIPTION
Adds ANTv2 ([`0xa117000000f279D81A1D3cc75430fAA017FA5A2e`](https://etherscan.io/address/0xa117000000f279d81a1d3cc75430faa017fa5a2e#code)).

- [Announcement](https://aragon.org/blog/antv2)
- [Repo](https://github.com/aragon/aragon-network-token)

-----

I've also taken the liberty of updating previously outdated information.

The link at `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png` is currently pending https://github.com/trustwallet/assets/pull/4616.