### PR TITLE
Add ADX-LOYALTY

### DIFF
--- a/tokens/eth/0xADE00C28244d5CE17D72E40330B1c318cD12B7c3.json
+++ b/tokens/eth/0xADE00C28244d5CE17D72E40330B1c318cD12B7c3.json
@@ -26,7 +26,7 @@
     "linkedin": "",
     "reddit": "https://www.reddit.com/r/AdEx",
     "slack": "",
-    "telegram": "",
+    "telegram": "https://telegram.me/AdExNetworkOfficial",
     "twitter": "https://twitter.com/AdEx_Network",
     "youtube": ""
   }

--- a/tokens/eth/0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C.json
+++ b/tokens/eth/0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "ADX-LOYALTY",
+  "address": "0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C",
+  "decimals": 18,
+  "name": "AdEx Loyalty",
+  "ens_address": "",
+  "website": "https://www.adex.network",
+  "logo": {
+    "src": "https://raw.githubusercontent.com/AdExNetwork/adex-brand/master/logos/ADX-loyalty@128x128.png",
+    "width": "128px",
+    "height": "128px",
+    "ipfs_hash": "QmRdkPtRDKCxKdQ96Uq869dPDMPSHkLaRNGhNXyYNtoCox"
+  },
+  "support": {
+    "email": "contactus@adex.network",
+    "url": "https://help.adex.network"
+  },
+  "social": {
+    "blog": "https://www.adex.network/blog",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/AdExNetwork",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/AdEx",
+    "slack": "",
+    "telegram": "https://telegram.me/AdExNetworkOfficial",
+    "twitter": "https://twitter.com/AdEx_Network",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
Hello :wave: ,
This PR is:

- Adding a derivative of `ADX` called `ADX-LOYALTY` which is used for governance by [AdEx.Network](https://AdEx.Network).
- Updating the `ADX` token by adding `telegram` to the `social` links.

Thanks!