### PR TITLE
Updated ARNX token logo

### DIFF
--- a/tokens/eth/0x0C37Bcf456bC661C14D596683325623076D7e283.json
+++ b/tokens/eth/0x0C37Bcf456bC661C14D596683325623076D7e283.json
@@ -1,10 +1,6 @@
 {
  "symbol": "ARNX",
-
  "name": "Aeron",
-
- "type": "ERC20",
-
  "address": "0x0C37Bcf456bC661C14D596683325623076D7e283",
  "ens_address": "",
  "decimals": 18,


### PR DESCRIPTION
It is requested to pull CoinGecko price data for this ARNX token (https://www.coingecko.com/en/coins/aeron) as legacy ARN token has been swapped