### PR TITLE
Deprecated contract address due to 2021 token swap

### DIFF
--- a/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
+++ b/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
@@ -31,4 +31,9 @@
     "twitter": "",
     "youtube": ""
   }
+  "deprecation": {
+    "new_address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
+    "migration_type": "announcement:https://encrypgen.com/the-big-dna-token-swap/",
+    "time": "2021-02-06 12:00:00 UTC"
+  }
 }

--- a/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
+++ b/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
@@ -1,11 +1,11 @@
 {
   "symbol": "DNA",
-  "name": "EncrypGen",
+  "name": "EncrypGen (old)",
   "type": "ERC20",
   "address": "0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81",
   "ens_address": "",
   "decimals": 18,
-  "website": "https://www.encrypgen.com",
+  "website": "",
   "logo": {
     "src": "",
     "width": "",
@@ -25,10 +25,10 @@
     "gitter": "",
     "instagram": "",
     "linkedin": "",
-    "reddit": "https://www.reddit.com/r/encrypgen",
+    "reddit": "",
     "slack": "",
     "telegram": "",
-    "twitter": "https://twitter.com/encrypgen",
+    "twitter": "",
     "youtube": ""
   }
 }

--- a/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
+++ b/tokens/eth/0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81.json
@@ -30,7 +30,7 @@
     "telegram": "",
     "twitter": "",
     "youtube": ""
-  }
+  },
   "deprecation": {
     "new_address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
     "migration_type": "announcement:https://encrypgen.com/the-big-dna-token-swap/",


### PR DESCRIPTION
Changing the name to EncrypGen (old) per company announcement of a migration to a new contract address (0xef6344de1fcfc5f48c30234c16c1389e8cdc572c), published on Etherscan and CoinGecko.  Created a new .json file for the replacement token, also included in this pull request.
Announcements:
https://etherscan.io/token/0x82b0e50478eeafde392d45d1259ed1071b6fda81
https://www.coingecko.com/en/coins/encrypgen
https://encrypgen.com/the-big-dna-token-swap/