### PR TITLE
New DNA token contract per Etherscan announcement

### DIFF
--- a/tokens/eth/0xef6344de1fcfC5F48c30234C16c1389e8CdC572C.json
+++ b/tokens/eth/0xef6344de1fcfC5F48c30234C16c1389e8CdC572C.json
@@ -1,7 +1,7 @@
 {
   "symbol": "DNA",
   "name": "EncrypGen",
-  "address": "0xef6344de1fcfc5f48c30234c16c1389e8cdc572c",
+  "address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
   "ens_address": "",
   "decimals": 18,
   "website": "https://encrypgen.com",

--- a/tokens/eth/0xef6344de1fcfc5f48c30234c16c1389e8cdc572c.json
+++ b/tokens/eth/0xef6344de1fcfc5f48c30234c16c1389e8cdc572c.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "DNA",
+  "name": "EncrypGen",
+  "address": "0xef6344de1fcfc5f48c30234c16c1389e8cdc572c",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://encrypgen.com",
+  "logo": {
+    "src": "https://encrypgen.com/logo128x128.png",
+    "width": "128",
+    "height": "128",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "info@encrypgen.com",
+    "url": ""
+  },
+  "social": {
+    "blog": "https://encrypgen.com/blog/",
+    "chat": "",
+    "facebook": "https://www.facebook.com/encrypgen/",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "https://www.linkedin.com/company/encrypgen-llc",
+    "reddit": "https://www.reddit.com/r/encrypgen",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/encrypgen",
+    "youtube": "https://www.youtube.com/channel/UC1qg5ZxwT4B2LNl8HUwj4NQ"
+  }
+}


### PR DESCRIPTION
The old DNA contract (0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81) is deprecated due to a recent token swap.  This .json file reflects the new contract address (0xef6344de1fcfC5F48c30234C16c1389e8CdC572C) per announcement on Etherscan, CoinGecko, and Encrypgen's blog:

https://etherscan.io/token/0x82b0e50478eeafde392d45d1259ed1071b6fda81
https://www.coingecko.com/en/coins/encrypgen
https://encrypgen.com/the-big-dna-token-swap/