### PR TITLE
Add LPT BondingManager

### DIFF
--- a/tokens/eth/0x511Bc4556D823Ae99630aE8de28b9B80Df90eA2e.json
+++ b/tokens/eth/0x511Bc4556D823Ae99630aE8de28b9B80Df90eA2e.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "LPT (Bonding)",
+  "address": "0x511Bc4556D823Ae99630aE8de28b9B80Df90eA2e",
+  "decimals": 18,
+  "name": "Livepeer Token Bonding Manager",
+  "ens_address": "",
+  "website": "https://livepeer.org/",
+  "logo": {
+    "src": "https://livepeer-dev.s3.amazonaws.com/logos/lpt_transparent_200.png",
+    "width": "200",
+    "height": "200",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "contact@livepeer.org",
+    "url": "https://forum.livepeer.org"
+  },
+  "social": {
+    "blog": "https://medium.com/livepeer-blog",
+    "chat": "https://discord.gg/RR4kFAh",
+    "facebook": "",
+    "forum": "https://forum.livepeer.org",
+    "github": "https://github.com/livepeer",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/livepeer/",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/LivepeerOrg",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
LPT has two separate contracts, one for allowance and one for bonding.

https://forum.livepeer.org/t/how-to-delegate-lpt-using-mycrypto-and-a-hardware-wallet-ledger-nano-s-trezor-etc/292/1

The existing LPT token in 0x58b6A8A3302369DAEc383334672404Ee733aB239.json can only be used to authorize the BondingManager.