### PR TITLE
Add NODL token on ZksSync Era Mainnet

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
@@ -21,7 +21,8 @@ val networkMapping = mapOf(
     "etc" to 61,
     "ella" to 64,
     "arb" to 42161,
-    "avax" to 43114
+    "avax" to 43114,
+    "zks" to 324
 )
 
 suspend fun main() {

--- a/tokens/zks/0xBD4372e44c5eE654dd838304006E1f0f69983154.json
+++ b/tokens/zks/0xBD4372e44c5eE654dd838304006E1f0f69983154.json
@@ -1,0 +1,24 @@
+{
+  "symbol": "NODL",
+  "address": "0xBD4372e44c5eE654dd838304006E1f0f69983154",
+  "decimals": 18,
+  "name": "NODL Token",
+  "website": "https://www.nodle.com",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "support@nodle.com"
+  },
+  "social": {
+    "blog": "https://nodle.medium.com",
+    "discord": "https://discord.gg/N5nTUt8RWJ",
+    "linkedin": "https://www.linkedin.com/company/nodle",
+    "telegram": "https://telegram.me/nodlecommunity",
+    "twitter": "https://x.com/nodlenetwork",
+    "youtube": "https://www.youtube.com/c/Nodle"
+  }
+}

--- a/tokens/zks/0xBD4372e44c5eE654dd838304006E1f0f69983154.json
+++ b/tokens/zks/0xBD4372e44c5eE654dd838304006E1f0f69983154.json
@@ -5,9 +5,9 @@
   "name": "NODL Token",
   "website": "https://www.nodle.com",
   "logo": {
-    "src": "",
-    "width": "",
-    "height": "",
+    "src": "https://raw.githubusercontent.com/NodleCode/assets/main/logo_256.png",
+    "width": "256",
+    "height": "256",
     "ipfs_hash": ""
   },
   "support": {


### PR DESCRIPTION
This PR adds a folder for ZKSync Era Mainnet abbreviated as "zks" with 324 as its chain id and list NODL token on that rollup network. The link to the contract is https://era.zksync.network/address/0xBD4372e44c5eE654dd838304006E1f0f69983154.

NODL had been [recently added to ZkSync](https://medium.com/nodle-io/nodle-is-launching-on-zksync-to-bring-its-fast-growing-depin-to-ethereum-strengthen-its-tech-plus-861a6f9abbce) but it has existed as a token on its own Parachain on Polkadot. Here is the link to the original NODL on Nodle parachain: https://nodleprotocol.io/?rpc=wss%3A%2F%2Fnodle-parachain.api.onfinality.io%2Fpublic-ws#/explorer