### PR TITLE
Create 0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b.json

### DIFF
--- a/tokens/arb/0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b.json
+++ b/tokens/arb/0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b.json
@@ -1,0 +1,27 @@
+{
+  "symbol": "SESH",
+  "address": "0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b",
+  "decimals": 9,
+  "name": "Session Token",
+  "type": "ERC20",
+  "ens_address": "",
+  "website": "https://token.getsession.org",
+  "logo": {
+    "src": "https://raw.githubusercontent.com/session-foundation/session-token-contracts/refs/heads/master/logos/SessionTokenLogo128px128px.png",
+    "width": "128",
+    "height": "128",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "url": "https://sessionapp.zendesk.com"
+  },
+  "social": {
+    "blog": "https://token.getsession.org/blog",
+    "chat": "https://discord.gg/sessiontoken",
+    "github": "https://github.com/session-foundation",
+    "instagram": "https://www.instagram.com/getsession",
+    "linkedin": "https://www.linkedin.com/company/sessionmessenger",
+    "twitter": "https://x.com/session_token",
+    "youtube": "https://www.youtube.com/@SessionTV"
+  }
+}

--- a/tokens/eth/0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b.json
+++ b/tokens/eth/0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b.json
@@ -1,0 +1,27 @@
+{
+  "symbol": "SESH",
+  "address": "0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b",
+  "decimals": 9,
+  "name": "Session Token",
+  "type": "ERC20",
+  "ens_address": "",
+  "website": "https://token.getsession.org",
+  "logo": {
+    "src": "https://raw.githubusercontent.com/session-foundation/session-token-contracts/refs/heads/master/logos/SessionTokenLogo128px128px.png",
+    "width": "128",
+    "height": "128",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "url": "https://sessionapp.zendesk.com"
+  },
+  "social": {
+    "blog": "https://token.getsession.org/blog",
+    "chat": "https://discord.gg/sessiontoken",
+    "github": "https://github.com/session-foundation",
+    "instagram": "https://www.instagram.com/getsession",
+    "linkedin": "https://www.linkedin.com/company/sessionmessenger",
+    "twitter": "https://x.com/session_token",
+    "youtube": "https://www.youtube.com/@SessionTV"
+  }
+}


### PR DESCRIPTION
This PR adds Session Token to both the Ethereum and Arbitrum token lists. The token uses the same contract address on both networks: 0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b

Since I wasn’t entirely sure of the convention for adding multi-chain tokens, I’ve created separate JSON files for Ethereum and Arbitrum. If this approach isn't correct, I’m happy to update the PR accordingly—just let me know.