### PR TITLE
Add WPLS (Wrapped Pulse) token on Ethereum mainnet

### DIFF
--- a/tokens/eth/0xA882606494D86804B5514E07e6Bd2D6a6eE6d68A.json
+++ b/tokens/eth/0xA882606494D86804B5514E07e6Bd2D6a6eE6d68A.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "WPLS",
+  "name": "Wrapped Pulse",
+  "type": "ERC20",
+  "address": "0xA882606494D86804B5514E07e6Bd2D6a6eE6d68A",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://pulsechain.com",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "",
+    "url": ""
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "",
+    "twitter": "",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
 ## Adding WPLS Token

  **Token Name**: Wrapped Pulse (WPLS)
  **Contract Address**: 0xA882606494D86804B5514E07e6Bd2D6a6eE6d68A
  **Chain**: Ethereum Mainnet
  **Type**: ERC20

  WPLS is the wrapped version of PLS (Pulse) from PulseChain, bridged to Ethereum mainnet.

  ### Verification
  - ✅ Contract address is ERC-55 checksummed
  - ✅ JSON formatted with prettier
  - ✅ Standard ERC20 token
  - ✅ All mandatory fields included

  ### Links
  - Website: https://pulsechain.com
  - Contract: https://etherscan.io/address/0xA882606494D86804B5514E07e6Bd2D6a6eE6d68A
