### PR TITLE
chore: allow base chain in CLI mapping

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/Main.kt
@@ -21,6 +21,7 @@ val networkMapping = mapOf(
     "etc" to 61,
     "ella" to 64,
     "sonic" to 146,
+    "base" to 8453,
     "arb" to 42161,
     "avax" to 43114,
     "zks" to 324,


### PR DESCRIPTION
## Summary
- add Base (8453) to the CLI network mapping so repositories with `tokens/base/` no longer fail `./gradlew run`

## Testing
- ./gradlew run