### PR TITLE
fix: avoid double parsing in checkTokenFile

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
@@ -64,11 +64,10 @@ fun getRPC(chainId: ChainId): EthereumRPC? {
 
 suspend fun checkTokenFile(file: File, onChainCheck: Boolean = false, chainId: ChainId? = null) {
 
-    file.reader().use { reader ->
-        Klaxon().parseJsonObject(reader).checkFields(mandatoryFields, optionalFields)
+    val jsonObject = file.reader().use { reader ->
+        Klaxon().parseJsonObject(reader) ?: throw InvalidJSON("Failed to parse token json")
     }
-
-    val jsonObject = Klaxon().parseJsonObject(file.reader())
+    jsonObject.checkFields(mandatoryFields, optionalFields)
     val address = Address(jsonObject["address"] as String)
     val addressEIP1191 = if (jsonObject["address_eip1191"] != null) Address(jsonObject["address_eip1191"] as String) else null
 


### PR DESCRIPTION
## Summary
- parse each token JSON inside a single `use` block so the reader is closed deterministically
- run `checkFields` on the parsed object instead of reparsing the file, preventing descriptor leaks
- surface a consistent `InvalidJSON` when parsing fails before validation begins

## Testing
- JAVA_HOME=$HOME/.jdks/jdk-17.0.13+11 PATH=$JAVA_HOME/bin:$PATH ./gradlew test
