### PR TITLE
fix: handle missing RPC endpoints for new chains

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/TokenChecker.kt
@@ -44,9 +44,14 @@ fun getRPC(chainId: ChainId): EthereumRPC? {
         return null
     }
     if (rpcMap[chainId.value] == null) {
-        val chain = chains?.first { it.chainId == chainId.value.toLong() }
+        val chain = chains?.firstOrNull { it.chainId == chainId.value.toLong() }
 
-        val rpc = chain?.rpc?.firstOrNull {
+        if (chain == null) {
+            println("No RPC endpoint available for chainId ${chainId.value} – ensure ethereum-lists/chains includes this network.")
+            return null
+        }
+
+        val rpc = chain.rpc?.firstOrNull {
             try {
                 HttpEthereumRPC(it).chainId()?.value == chainId.value
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- use `firstOrNull` when resolving chain metadata so we don't crash if chains repo lacks the new network
- emit a descriptive warning and skip on-chain checks when no RPC endpoint can be discovered
- keep existing caching behaviour for chains that do resolve

## Testing
- JAVA_HOME=$HOME/.jdks/jdk-17.0.13+11 PATH=$JAVA_HOME/bin:$PATH ./gradlew test
