### PR TITLE
fix: avoid rewriting decimals when no change needed

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/CorrectDecimals.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/CorrectDecimals.kt
@@ -6,15 +6,15 @@ fun main() {
 
     allNetworksTokenDir.listFiles().forEach { singleNetworkTokenDirectory ->
         singleNetworkTokenDirectory.listFiles().forEach {
-            val jsonObject =it.reader().use { reader ->
+            val jsonObject = it.reader().use { reader ->
                 Klaxon().parseJsonObject(reader)
             }
             val decimals = jsonObject["decimals"]
             if (decimals is String) {
                 println("got string decimal - rewrite")
-                jsonObject["decimals"] =  Integer.parseInt( decimals )
+                jsonObject["decimals"] = Integer.parseInt(decimals)
+                it.writeText(jsonObject.toJsonString(true))
             }
-            it.writeText(jsonObject.toJsonString(true))
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop rewriting every token JSON when running `correctDecimals`
- only convert and persist files that actually specify decimals as strings
- keep the existing console message for visibility when conversions happen

## Testing
- JAVA_HOME=$HOME/.jdks/jdk-17.0.13+11 PATH=$JAVA_HOME/bin:$PATH ./gradlew test
