### PR TITLE
docs: correct onChainCheck usage hint

### DIFF
--- a/src/main/kotlin/org/ethereum/lists/tokens/OnChainCheck.kt
+++ b/src/main/kotlin/org/ethereum/lists/tokens/OnChainCheck.kt
@@ -6,7 +6,10 @@ import kotlin.system.exitProcess
 suspend fun main(args: Array<String>) {
 
     if (args.isEmpty()) {
-        error("fileToCheck not specified :-)\nPlease execute like this: ./gradlew -PfileToCheckh=/path/you/want/to/import")
+        error(
+            "fileToCheck not specified :-)\n" +
+                "Please execute like this: ./gradlew onChainCheck -PfileToCheck=tokens/<chain>/<address>.json"
+        )
     }
 
     val fileToCheck = File(args[0])


### PR DESCRIPTION
## Summary
- fix the CLI guidance printed by `onChainCheck` to show the correct Gradle task invocation
- keep the friendly wording while pointing at a valid `tokens/<chain>/<address>.json` example

## Testing
- JAVA_HOME=$HOME/.jdks/jdk-17.0.13+11 PATH=$JAVA_HOME/bin:$PATH ./gradlew test
