### PR TITLE
Add Luckycoin (LUK) token for Plasma network

### DIFF
--- a/tokens/plasma/0xC1b471A3228Aa15571c05e79a002a26eDF6F3C9d.json
+++ b/tokens/plasma/0xC1b471A3228Aa15571c05e79a002a26eDF6F3C9d.json
@@ -1,0 +1,33 @@
+{
+    "symbol": "LUK",
+    "address": "0xC1b471A3228Aa15571c05e79a002a26eDF6F3C9d",
+    "decimals": 0,
+    "name": "Luckycoin",
+    "ens_address": "",
+    "website": "https://luckycoinvn.vercel.app",
+    "logo": {
+        "src": "https://raw.githubusercontent.com/coinnetworkbi/luckycoin/main/tokens/logo.png",
+        "width": 256,
+        "height": 256,
+        "ipfs_hash": ""
+    },
+    "support": {
+        "email": "coinnetworkbi@gmail.com",
+        "url": ""
+    },
+    "social": {
+        "blog": "",
+        "chat": "",
+        "facebook": "",
+        "forum": "",
+        "github": "https://github.com/coinnetworkbi/luckycoin/tree/main/tokens",
+        "gitter": "",
+        "instagram": "",
+        "linkedin": "",
+        "reddit": "",
+        "slack": "",
+        "telegram": "",
+        "twitter": "https://x.com/luckycoinvn",
+        "youtube": ""
+    }
+}


### PR DESCRIPTION
This PR adds the Luckycoin (LUK) token for the Plasma network to the ethereum-lists/tokens repository.

Token details:
- Name: Luckycoin
- Symbol: LUK
- Address: 0xC1b471A3228Aa15571c05e79a002a26eDF6F3C9d
- Decimals: 0
- ChainId: 9745 (Plasma)
- Website: https://luckycoinvn.vercel.app
- Logo: https://raw.githubusercontent.com/coinnetworkbi/luckycoin/main/tokens/logo.png

Support and social links are provided in the JSON metadata.

This addition allows wallets like Rabby and other EVM-compatible wallets to display Luckycoin and its logo correctly.
