### PR TITLE
Add GoldenArmorStudioCoin metadata

### DIFF
--- a/tokens/eth/0xfdfca393Ebf5D6E389d5D3A679504a3182deBED9.json
+++ b/tokens/eth/0xfdfca393Ebf5D6E389d5D3A679504a3182deBED9.json
@@ -1,0 +1,32 @@
+{
+  "symbol": "GASC",
+  "address": "0xfdfca393Ebf5D6E389d5D3A679504a3182deBED9",
+  "decimals": 18,
+  "name": "GoldenArmorStudioCoin",
+  "type": "ERC20",
+  "website": "https://goldenarmorstudio.art/",
+  "logo": {
+    "src": "https://raw.githubusercontent.com/Golden-Armor-Studios/GoldenArmorStudioCoin/main/docs/assets/gasc-logo.png",
+    "width": "512",
+    "height": "512"
+  },
+  "support": {
+    "email": "info@goldenarmorstudio.art",
+    "url": "https://goldenarmorstudio.art/"
+  },
+  "social": {
+    "blog": "",
+    "chat": "https://discord.gg/goldenarmorstudio",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/Golden-Armor-Studios/GoldenArmorStudioCoin",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/goldenarmorstudio",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
Add GoldenArmorStudioCoin to a dedicated token list
  (goldenarmor.tokenlist.json) with:
  - Mainnet token metadata (address
  0x7D7f9D7426e54de08B1428fA90F3d0B6D6F02c3F)
  - Repo-hosted logo URI
  - Organization links (website, GitHub, Discord)

  Validation: yarn install && yarn test