### PR TITLE
Add Akashi Token (AKASHI)  Base Sepolia

### DIFF
--- a/tokens/eth/0xf2acb725e372603f70d894ae5fbc83b2f8f3d79e.json
+++ b/tokens/eth/0xf2acb725e372603f70d894ae5fbc83b2f8f3d79e.json
@@ -1,0 +1,9 @@
+{
+  "name": "Akashi Token",
+  "symbol": "AKASHI",
+  "decimals": 18,
+  "address": "0xf2acb725e372603f70d894ae5fbc83b2f8f3d79e",
+  "chainId": 84532,
+  "logoURI": "https://raw.githubusercontent.com/Akashionchain/akashi-token-assets/main/akashi-token-logo.png",
+  "tags": ["erc20", "community"]
+}


### PR DESCRIPTION
## Akashi Token (AKASHI)  Base Sepolia

Hello maintainers 
I’m submitting the metadata and logo for **Akashi Token (AKASHI)** deployed on **Base Sepolia**.

This PR adds the token JSON definition under `tokens/eth/` using the contract address as the filename.

---

## Token Information

- **Name:** Akashi Token  
- **Symbol:** AKASHI  
- **Decimals:** 18  
- **Chain ID:** 84532 (Base Sepolia Testnet)  
- **Contract Address:** 0xf2acb725e372603f70d894ae5fbc83b2f8f3d79e  
- **Standard:** ERC-20

---

## Included Files

1. **Token metadata JSON**  
2. **Token logo PNG** (transparent background, optimized for UI use)

---

If anything needs updating or adjusting, I’m happy to make the changes.  
Thank you!
