### PR TITLE
feat: add BasedBase (BASW) on Base Chain

### DIFF
--- a/tokens/base/0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade.json
+++ b/tokens/base/0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade.json
@@ -1,0 +1,14 @@
+{
+  "symbol": "BASE",
+  "address": "0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade",
+  "decimals": 18,
+  "name": "Base",
+  "type": "ERC20",
+  "website": "https://basw.vercel.app/",
+  "logo": {
+    "src": "https://cdn.brandfetch.io/id6XsSOVVS/w/400/h/400/theme/dark/icon.jpeg?c=1dxbfHSJFAPEGdCLU4o5B"
+  },
+  "social": {
+    "github": "https://github.com/basedBase/basw"
+  }
+}


### PR DESCRIPTION
This PR adds BasedBase (BASW) token information on the Base Chain (Chain ID: 8453). Token Address: 0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade. Website: https://basw.vercel.app/