### PR TITLE
Add BANKC (BankCrypto.com) ERC20 token

### DIFF
--- a/tokens/eth/0xa593DECC9100f0014ff8EE07735F7b8EeFB7E055.json
+++ b/tokens/eth/0xa593DECC9100f0014ff8EE07735F7b8EeFB7E055.json
@@ -1,0 +1,33 @@
+{
+  "symbol": "BANKC",
+  "address": "0xa593DECC9100f0014ff8EE07735F7b8EeFB7E055",
+  "decimals": 18,
+  "name": "BankCrypto.com",
+  "ens_address": "",
+  "website": "https://bankcrypto.com",
+  "logo": {
+    "src": "https://bankcrypto.com/logo.png",
+    "width": 400,
+    "height": 400,
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "tamaragroup@pm.me",
+    "url": "https://bankcrypto.com"
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "",
+    "twitter": "",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
## Token Details

- **Name:** BankCrypto.com
- **Symbol:** BANKC
- **Address:** 0xa593DECC9100f0014ff8EE07735F7b8EeFB7E055
- **Decimals:** 18
- **Chain:** Ethereum mainnet

## Verification

- Contract source verified on Etherscan
- Standard ERC20 (no proxy, no mint function, 0% tax)
- Active liquidity on Uniswap V3 and SushiSwap V3
- Website: https://bankcrypto.com
- Token list (Uniswap TokenList spec): https://bankcrypto.com/tokenlist.json

## Security Reports

- GoPlus: Not honeypot, 0% buy/sell tax, open source
- Honeypot.is: Clean

## Links

- Etherscan: https://etherscan.io/token/0xa593DECC9100f0014ff8EE07735F7b8EeFB7E055
- DEXScreener: https://dexscreener.com/ethereum/0xf0b694cfee0ab11f3d1497dae6e7ee9251b885d1
- DexTools: https://www.dextools.io/app/ether/pair-explorer/0xf0b694cfee0ab11f3d1497dae6e7ee9251b885d1