### PR TITLE
feat: add HEDGE token (Hedgehog Protocol) on Sonic chain

### DIFF
--- a/tokens/sonic/0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c.json
+++ b/tokens/sonic/0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "HEDGE",
+  "name": "Hedge Token",
+  "type": "ERC20",
+  "address": "0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://sonicpump.meme",
+  "logo": {
+    "src": "https://i.imgur.com/IXYOX7V.png",
+    "width": "1024",
+    "height": "1024",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "",
+    "url": "https://sonicpump.meme"
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/iamdexx/HedgeCore",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/SonicPump",
+    "twitter": "https://x.com/sonicpumpmeme",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
## Summary

Adds the HEDGE token from Hedgehog Protocol to the Sonic chain token list.

**Token Details:**
- Name: Hedge Token
- Symbol: HEDGE
- Contract: `0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c` (ERC-55 checksummed)
- Decimals: 18
- Chain: Sonic (chain ID 146)
- Type: ERC-20

**Protocol:** [Hedgehog Protocol](https://sonicpump.meme) — permissionless meme token launchpad on Sonic with bonding curve liquidity.

**Links:**
- Website: https://sonicpump.meme
- Twitter: https://x.com/sonicpumpmeme
- Telegram: https://t.me/SonicPump
- GitHub: https://github.com/iamdexx/HedgeCore
- SonicScan: https://sonicscan.org/token/0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c