### PR TITLE
Add POSCI (Proof of Scientist)

### DIFF
--- a/tokens/eth/0xFbcF59DE93B4c62e0EEe21280c9EAA75AFb1E26c.json
+++ b/tokens/eth/0xFbcF59DE93B4c62e0EEe21280c9EAA75AFb1E26c.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "POSCI",
+  "name": "Proof of Scientist",
+  "type": "ERC20",
+  "address": "0xFbcF59DE93B4c62e0EEe21280c9EAA75AFb1E26c",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://scientistdapp.online",
+  "logo": {
+    "src": "https://scientistdapp.online/posci-logo-128.png",
+    "width": "128",
+    "height": "128",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "",
+    "url": "https://scientistdapp.online"
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://x.com/scientistsdapp",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
**Token:** Proof of Scientist (POSCI)
**Address:** `0xFbcF59DE93B4c62e0EEe21280c9EAA75AFb1E26c`
**Website:** https://scientistdapp.online
**Twitter:** https://x.com/scientistsdapp

Proof of Scientist (POSCI) is a 21,000,000 fixed-supply, owner-less, PoW-mined ERC20 on Ethereum mainnet. 95% of supply is mined, not sold. The hash includes msg.sender so a copied nonce is worthless to anyone else — there is no MEV surface to exploit. The genesis sale fills a 0.5 ETH cap and atomically initializes a Uniswap V4 pool with the liquidity NFT permanently burned to 0x000…dEaD.

Etherscan: https://etherscan.io/token/0xFbcF59DE93B4c62e0EEe21280c9EAA75AFb1E26c