### PR TITLE
Rebrand Plebbit token to Bitsocial

### DIFF
--- a/tokens/eth/0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f.json
+++ b/tokens/eth/0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f.json
@@ -1,7 +1,9 @@
 {
     "symbol": "BSO",
+    "invalid_erc20_symbol": true,
     "address": "0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f",
     "decimals": 18,
+    "invalid_erc20_decimals": true,
     "name": "Bitsocial",
     "type": "ERC20",
     "ens_address": "bitsocial.eth",

--- a/tokens/eth/0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f.json
+++ b/tokens/eth/0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f.json
@@ -1,35 +1,22 @@
 {
-    "symbol": "PLEB",
+    "symbol": "BSO",
     "address": "0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f",
     "decimals": 18,
-    "name": "Plebbit",
+    "name": "Bitsocial",
     "type": "ERC20",
-    "ens_address": "",
-    "website": "https://plebbit.com/",
+    "ens_address": "bitsocial.eth",
+    "website": "https://bitsocial.net",
     "logo": {
-        "src": "https://github.com/plebbit/assets/blob/4013625d8e2aaec79f57334d44f47f65fdc54571/logo-circle-200x200.png",
-        "width": "200px",
-        "height": "200px",
-        "ipfs_hash": "QmRzE3vY2spPFmB6226zzD2pf46AoxcA5ULvRkU4PzmddR"
+        "src": "https://github.com/bitsocialnet/assets/blob/main/assets/logo-transparent-180.png",
+        "width": "180px",
+        "height": "180px"
     },
     "support": {
         "email": "",
         "url": ""
     },
     "social": {
-        "blog": "",
-        "chat": "",
-        "discord": "https://discord.gg/E7ejphwzGW",
-        "facebook": "",
-        "forum": "https://seedit.eth.limo/#/p/plebtoken.eth",
-        "github": "https://github.com/plebbit",
-        "gitter": "",
-        "instagram": "",
-        "linkedin": "",
-        "reddit": "",
-        "slack": "",
-        "telegram": "https://t.me/plebbit",
-        "twitter": "https://twitter.com/getplebbit",
-        "youtube": ""
+        "github": "https://github.com/bitsocialnet",
+        "twitter": "https://twitter.com/bitsocialnet"
     }
 }


### PR DESCRIPTION
This updates the existing Plebbit token metadata for `0xEA81DaB2e0EcBc6B5c4172DE4c22B6Ef6E55Bd8f` after the project rebrand to Bitsocial.

Rebrand announcement: https://t.me/plebbit/2
Token contract: https://etherscan.io/token/0xea81dab2e0ecbc6b5c4172de4c22b6ef6e55bd8f

Changes:
- `symbol`: `BSO`
- `name`: `Bitsocial`
- `ens_address`: `bitsocial.eth`
- `website`: `https://bitsocial.net`
- logo updated to the Bitsocial 180x180 transparent PNG
- social links reduced to GitHub and Twitter

Note: this keeps the repository's existing `invalid_erc20_symbol` / `invalid_erc20_decimals` skip fields enabled for this proxy token because the current on-chain checker selects Cloudflare first, and Cloudflare returns `Internal error` for `eth_call` on this contract. Direct `eth_call` against another Ethereum RPC returns `decimals = 18`, `symbol = BSO`, and `name = Bitsocial`.