### PR TITLE
eat: add wUSDT, USDB, and ONE token assets for BEXChain

### DIFF
--- a/tokens/bexchain/0x3f1c8a5244a8959116e6e01df5e13847b7e11726.json
+++ b/tokens/bexchain/0x3f1c8a5244a8959116e6e01df5e13847b7e11726.json
@@ -1,0 +1,7 @@
+{
+  "address": "0x3f1c8a5244a8959116e6e01df5e13847b7e11726",
+  "name": "USDB",
+  "symbol": "USDB",
+  "decimals": 18,
+  "website": "https://bexchain.com"
+}

--- a/tokens/bexchain/0x635bdb62f35e1971b96fb9609cbdd2dab4fa91fe.json
+++ b/tokens/bexchain/0x635bdb62f35e1971b96fb9609cbdd2dab4fa91fe.json
@@ -1,0 +1,7 @@
+{
+  "address": "0x635bdb62f35e1971b96fb9609cbdd2dab4fa91fe",
+  "name": "ONE",
+  "symbol": "ONE",
+  "decimals": 18,
+  "website": "https://bexchain.com"
+}

--- a/tokens/bexchain/0xbc6593358feea849a059fe2c8bcb48d138abee50.json
+++ b/tokens/bexchain/0xbc6593358feea849a059fe2c8bcb48d138abee50.json
@@ -1,0 +1,7 @@
+{
+  "address": "0xbc6593358feea849a059fe2c8bcb48d138abee50",
+  "name": "USDT",
+  "symbol": "wUSDT",
+  "decimals": 18,
+  "website": "https://bexchain.com"
+}


### PR DESCRIPTION
Adding verified BEX20 token assets for the BEXChain network ecosystem.

- Network: BEXChain (Chain ID 140586)
- wUSDT Contract: 0xbc6593358feea849a059fe2c8bcb48d138abee50
- USDB Contract: 0x3f1c8a5244a8959116e6e01df5e13847b7e11726
- ONE Contract: 0x635bdb62f35e1971b96fb9609cbdd2dab4fa91fe
