### PR TITLE
Add Kamirai token on BSC

### DIFF
--- a/tokens/bsc/0x12bfe0251Eb64c6e26d1A264673593D6164ca213.json
+++ b/tokens/bsc/0x12bfe0251Eb64c6e26d1A264673593D6164ca213.json
@@ -1,0 +1,21 @@
+{
+  "symbol": "$KAMIRAI",
+  "name": "Kamirai",
+  "address": "0x12bfe0251Eb64c6e26d1A264673593D6164ca213",
+  "decimals": 18,
+  "type": "BEP20",
+  "website": "https://www.kamirai.io/",
+  "logo": {
+    "src": "https://kamirai-token-progress-dashboard.vercel.app/brand/KAMIRAI-0x12bfe0251Eb64c6e26d1A264673593D6164ca213-bsc.png",
+    "width": "128",
+    "height": "128"
+  },
+  "support": {
+    "email": "kami@kamirai.io",
+    "url": "https://www.kamirai.io/"
+  },
+  "social": {
+    "twitter": "https://x.com/KamiraiOfficial",
+    "telegram": "https://t.me/KamiraiGroup"
+  }
+}


### PR DESCRIPTION
## Token details

- **Name:** Kamirai
- **On-chain symbol:** `$KAMIRAI` (the dollar sign is intentional)
- **Network:** BNB Smart Chain (chain ID 56)
- **Standard:** BEP-20
- **Contract:** https://bscscan.com/token/0x12bfe0251eb64c6e26d1a264673593d6164ca213
- **Official website:** https://www.kamirai.io/
- **CoinMarketCap:** https://coinmarketcap.com/currencies/kamirai/
- **CoinGecko:** Not listed; no CoinGecko ID is available.
- **Kredict audit:** https://github.com/kredict/audit/blob/main/KAMIRAI-AUDIT-KREDICT.pdf
- **Cyberscope audit:** https://www.cyberscope.io/audits/kamirai
- **Logo:** https://kamirai-token-progress-dashboard.vercel.app/brand/KAMIRAI-0x12bfe0251Eb64c6e26d1A264673593D6164ca213-bsc.png

## Trezor support context

Because this token has no CoinGecko ID, the project contacted Trezor Support and requested consideration of its CoinMarketCap page and public evidence as an alternative identifier. This pull request does not claim Trezor approval.

- **Ticket-submission evidence:** https://kamirai-token-progress-dashboard.vercel.app/evidence/Trezor-support-ticket-submitted.webp
- **Request details:** https://kamirai-token-progress-dashboard.vercel.app/evidence/Trezor-request-details.png

## Change

This pull request adds one checksum-named token definition file under `tokens/bsc`. The contract address, symbol, and decimals match the deployed BSC token.