### PR TITLE
Add Inferno (IFR) token metadata

### DIFF
--- a/tokens/eth/0x77e99917Eca8539c62F509ED1193ac36580A6e7B.json
+++ b/tokens/eth/0x77e99917Eca8539c62F509ED1193ac36580A6e7B.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "IFR",
+  "address": "0x77e99917Eca8539c62F509ED1193ac36580A6e7B",
+  "decimals": 9,
+  "name": "Inferno",
+  "type": "ERC20",
+  "ens_address": "",
+  "website": "https://ifrunit.tech",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "kaspartisan@proton.me",
+    "url": "https://ifrunit.tech"
+  },
+  "social": {
+    "blog": "",
+    "chat": "https://t.me/IFR_token",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/NeaBouli/inferno",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/IFRtoken",
+    "twitter": "https://x.com/IFRtoken",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
## Summary

Replacement for #1036, which was closed automatically as stale and could not be reopened through GitHub.

Adds Inferno (IFR) metadata for the canonical Ethereum Mainnet contract:
`0x77e99917Eca8539c62F509ED1193ac36580A6e7B`

## Current evidence

- Etherscan reputation: Neutral
- Official token list: https://ifrunit.tech/token-list.json
- Well-known token list: https://ifrunit.tech/.well-known/token-list.json
- Official icon: https://ifrunit.tech/assets/ifr_icon_256.png
- GeckoTerminal pool: https://www.geckoterminal.com/eth/pools/0xbE495E9c0d8cc2DCf95570cf95B63c4844dF31A0

## Validation

- JSON parsing passed
- `./gradlew run` passed on the current upstream `master`

No parallel token-metadata request will be opened while this replacement is under review.
