### PR TITLE
Add ZRT (CryptoZR DAO Token)

### DIFF
--- a/tokens/eth/0x0c862C4Aff0c87F3b4e93350Ecf2DD6ADA0C5400.json
+++ b/tokens/eth/0x0c862C4Aff0c87F3b4e93350Ecf2DD6ADA0C5400.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "ZRT",
+  "address": "0x0c862C4Aff0c87F3b4e93350Ecf2DD6ADA0C5400",
+  "decimals": 18,
+  "name": "CryptoZR DAO Token",
+  "type": "ERC20",
+  "ens_address": "",
+  "website": "https://bidder.club",
+  "logo": {
+    "src": "https://raw.githubusercontent.com/CryptoZR/ZRDAO/main/assets/zrt_logo_128.png",
+    "width": "128",
+    "height": "128",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "i@bidder.club",
+    "url": ""
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/CryptoZR/ZRDAO",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/ZRDAOglobal",
+    "twitter": "https://x.com/BidderClub",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
## Add ZRT (CryptoZR DAO Token)

- **Address**: `0x0c862C4Aff0c87F3b4e93350Ecf2DD6ADA0C5400` (ERC-55 checksummed, matches filename)
- **Symbol / Name / Decimals**: `ZRT` / `CryptoZR DAO Token` / `18` — all match the on-chain values ([Etherscan, source verified](https://etherscan.io/token/0x0c862C4Aff0c87F3b4e93350Ecf2DD6ADA0C5400))
- **Website**: https://bidder.club
- **Logo**: square 128x128 transparent PNG hosted at the project's GitHub repository

ZRT is the governance token of ZRDAO, a decentralized autonomous organization led by crypto artist CryptoZR. Deployed on Ethereum mainnet 2026-07, max supply 2.1B, traded on Uniswap V2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
